### PR TITLE
fix: explicitly set core.abbrev=8 while getting hash

### DIFF
--- a/rev.py
+++ b/rev.py
@@ -1,7 +1,7 @@
 import subprocess
 
 def get_git_specifier():
-    rev_stat = subprocess.run(['git rev-parse --short HEAD --'], shell=True, capture_output=True)
+    rev_stat = subprocess.run(['git -c core.abbrev=8 rev-parse --short HEAD --'], shell=True, capture_output=True)
     if rev_stat.returncode != 0:
         print("Error describing git revision.")
         exit(-1)


### PR DESCRIPTION
The core.abbrev configuration in git allows the user to set the short hash to a different length. This is common to do for a lot of developers in large projects such as the Linux Kernel where a longer short hash is desired due to the number of commits. Currently, if the user has this configuration set, the build will fail if -Werror=overflow is set due to the larger value given by `git rev-parse`.

Fix the issue by explicitly setting core.abbrev=8 when running rev-parse.